### PR TITLE
Update release deployment

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,7 @@
 
 1. Wait for any running [Travis builds](https://travis-ci.com/github/cloudstateio/springboot-support/builds) to complete.
 
-2. Create a [release and tag](https://github.com/cloudstateio/springboot-support/releases) for the next version.
+2. Create an annotated tag (with `git tag -a vX.Y.Z`) and then [release](https://github.com/cloudstateio/springboot-support/releases) for the next version.
 
 3. Travis will start a [build](https://travis-ci.com/github/cloudstateio/springboot-support/builds) and publish to Bintray, and then sync to Maven Central.
 

--- a/deployment/deploy-release.sh
+++ b/deployment/deploy-release.sh
@@ -6,7 +6,8 @@ mvn --projects cloudstate-springboot-support -am deploy --settings deployment/se
 
 # Sync to Maven Central via Bintray
 
-readonly version=$(git describe --tags --exact-match)
+readonly tag=$(git describe --tags --exact-match)
+readonly version=${tag#v}
 
 [ -z "$version" ] && echo "No version tag for current commit" && exit 1
 


### PR DESCRIPTION
A couple of small updates for releasing (which I don't think had used the script yet). Expects an annotated tag, and wasn't stripping the `v` from the version tag for maven central sync. Deployment worked fine running manually.